### PR TITLE
add: allow close confirm without touching the dialog

### DIFF
--- a/src/ConfirmContext.ts
+++ b/src/ConfirmContext.ts
@@ -4,10 +4,12 @@ import { ConfirmFunction } from './types';
 
 export type ConfirmContextValue = {
   confirm: ConfirmFunction;
+  close: VoidFunction;
 };
 
 const ConfirmContext: React.Context<ConfirmContextValue> = React.createContext({
   confirm: (_: any) => Promise.resolve<boolean>(false),
+  close: () => {},
 });
 
 export default ConfirmContext;

--- a/src/ConfirmProvider.spec.tsx
+++ b/src/ConfirmProvider.spec.tsx
@@ -130,3 +130,28 @@ it('should get user cancellation', async () => {
     expect(screen.queryByText(/Test-isCancelled/)).toBeInTheDocument();
   });
 });
+
+it('should close component without touching the dialog', () => {
+  const TestComponent = () => {
+    const { confirm, close } = React.useContext(ConfirmContext);
+    return (
+      <>
+        <button onClick={() => confirm()}>open confirm</button>
+        <button onClick={close}>close confirm</button>
+      </>
+    );
+  };
+  render(
+    <ConfirmProvider dialog={ConfirmDialog}>
+      <TestComponent />
+    </ConfirmProvider>
+  );
+
+  fireEvent.click(screen.getByText(/open confirm/));
+
+  expect(screen.queryByText(/ConfirmDialog-open/)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText(/close confirm/));
+
+  expect(screen.queryByText(/ConfirmDialog-closed/)).toBeInTheDocument();
+});

--- a/src/ConfirmProvider.tsx
+++ b/src/ConfirmProvider.tsx
@@ -30,6 +30,10 @@ export default function ConfirmProvider({
     },
     []
   );
+  const close = React.useCallback<VoidFunction>(
+    () => setDialogProps({ isOpen: false }),
+    []
+  );
 
   const handleConfirm = () => {
     setDialogProps({ isOpen: false });
@@ -47,7 +51,10 @@ export default function ConfirmProvider({
     promiseRef.current[0](false);
   };
 
-  const contextValue = React.useMemo(() => ({ confirm }), [confirm]);
+  const contextValue = React.useMemo(() => ({ confirm, close }), [
+    confirm,
+    close,
+  ]);
 
   const DialogComponent = dialog as React.ComponentType<DialogProps>;
 

--- a/src/useConfirm.spec.tsx
+++ b/src/useConfirm.spec.tsx
@@ -7,6 +7,7 @@ import useConfirm from './useConfirm';
 it('should get context value', () => {
   const contextValue = {
     confirm: () => Promise.resolve<boolean>(false),
+    close: () => {},
   };
   const { result } = renderHook(useConfirm, {
     wrapper: ({ children }) => (


### PR DESCRIPTION
Add feature:
- Allow closing without touching the dialog. (E.g: Close confirm when changing page).